### PR TITLE
INFRA-8074 Update docker registry

### DIFF
--- a/base/{{cookiecutter.repo_name}}/Makefile
+++ b/base/{{cookiecutter.repo_name}}/Makefile
@@ -12,7 +12,7 @@ pipenv_version := 2018.11.26
 black_version := 18.9b0
 
 # Generated variables.
-main_image := registry:5000/jenkins/$(service):$(tag)
+main_image := registry.internal.telnyx.com/jenkins/$(service):$(tag)
 docker_build_args = \
 	--build-arg GIT_COMMIT=$(shell git show -s --format=%H) \
 	--build-arg GIT_COMMIT_DATE="$(shell git show -s --format=%ci)" \


### PR DESCRIPTION
This automatic PR updates ocurrences of 'registry:5000' to 'registry.internal.telnyx.com'. This change should be safe as 'registry:5000' is a pretty unique string. Double-check if any binary file has been updated